### PR TITLE
PRO-8251 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node app",
     "dev": "nodemon",
-    "build": "bash ./scripts/release-tasks",
+    "build": "NODE_ENV=production node app @apostrophecms/asset:build",
     "serve": "NODE_ENV=production node app",
     "release": "npm install && npm run build && node app @apostrophecms/migration:migrate"
   },

--- a/scripts/release-tasks
+++ b/scripts/release-tasks
@@ -1,1 +1,0 @@
-node app @apostrophecms/asset:build || exit 1

--- a/scripts/release-tasks
+++ b/scripts/release-tasks
@@ -1,5 +1,1 @@
-export APOS_RELEASE_ID=`cat /dev/urandom |env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
-
-echo $APOS_RELEASE_ID > ./release-id
-
 node app @apostrophecms/asset:build || exit 1


### PR DESCRIPTION
Please do a fresh checkout of this PR and give it a try. I did:

```
npm install
export NODE_ENV=production
npm run build && npm run serve

```

IMPORTANT NOTE: if you set `NODE_ENV=production` before `npm install` nodemon will not be installed because it is a dev dependency. If you avoid that pitfall, or clear the env var and then `npm install` again, `npm run dev` also works.
